### PR TITLE
Fix error with urlparse.urlunsplit

### DIFF
--- a/makepkg
+++ b/makepkg
@@ -92,7 +92,7 @@ import pwd
 import grp
 import shutil
 import urllib
-import urlparse
+from ansible.module_utils.six.moves.urllib.parse import urlsplit
 
 PACMAN_PATH = "/usr/bin/pacman"
 MAKEPKG_PATH = "/usr/bin/makepkg"
@@ -179,7 +179,7 @@ def make_package(module, pkg, pkg_file_src):
         except Exception, err:
             module.fail_json(msg="failed to copy package %s to build directory %s: %s" % (pkg_file_src, build_dir, str(err)))
     else:
-        aur_req = urlparse.urlunsplit((AUR_SCHEME, AUR_NETLOC, "%s/%s" % (AUR_SNAPSHOT_PATH, pkg_file_basename), "", ""))
+        aur_req = urlunsplit((AUR_SCHEME, AUR_NETLOC, "%s/%s" % (AUR_SNAPSHOT_PATH, pkg_file_basename), "", ""))
         rsp, info = fetch_url(module, aur_req)
 
         if info['status'] != 200:
@@ -262,7 +262,7 @@ def install_package(module, pkg, pkg_file):
     if not pkg_file:
         # this is an aur pkg
         rpc_params = urllib.urlencode({"type": "info", "arg": pkg})
-        rpc_req = urlparse.urlunsplit((AUR_SCHEME, AUR_NETLOC, AUR_RPC_PATH, rpc_params, ""))
+        rpc_req = urlunsplit((AUR_SCHEME, AUR_NETLOC, AUR_RPC_PATH, rpc_params, ""))
         rsp, info = fetch_url(module, rpc_req)
 
         # create a temporary file and copy content to do checksum-based replacement

--- a/makepkg
+++ b/makepkg
@@ -92,7 +92,7 @@ import pwd
 import grp
 import shutil
 import urllib
-from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from ansible.module_utils.six.moves.urllib.parse import urlunsplit
 
 PACMAN_PATH = "/usr/bin/pacman"
 MAKEPKG_PATH = "/usr/bin/makepkg"


### PR DESCRIPTION
This fixes the error message "AttributeError: 'function' object has no
attribute 'urlunsplit'".

The fix is taken directly from ansible/ansible-modules-core, see link:
https://github.com/ansible/ansible-modules-core/pull/3902